### PR TITLE
fix: Dynamically generate year and update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,31 @@ This is a repo for example usage of [encites](https://github.com/cutenode/encite
 
 ### report.js
 
-This is a baisc report that you can run, showing off the most complicated potential usage of the encites API. It saves raw data, filtered data, timestamped Markdown files (via [luxon](https://npm.im/luxon)), and overwrites `report.md` with the most recent markdown output.
+This is a basic report that you can run, showing off the most complicated potential usage of the encites API. It saves raw data, filtered data, timestamped Markdown files (via [luxon](https://npm.im/luxon)), and overwrites `report.md` with the most recent markdown output.
 
 > **Note:** As of encites@3.0.0, there is a bug in encites when writing new directories. If you encounter this when running this on your own, just run it a couple times and the directories will resolve themselves. This will be  resolved in a future release of encites.
 
-To run `report.js`, clone the repo and run the following commands:
+To generate a report:
 
-```
-npm install
-node report.js
-```
+1. Clone the repo
+
+2. Remove the `output/` directory
+
+3. Update the `people` array in [util/people.js](util/people.js)
+
+4. [Configure GitHub authentication](https://github.com/cutenode/encites#environment-variables)
+
+5. Install the example report tool
+
+    ```console
+    npm install
+    ```
+
+6. Run the example report generator
+
+    ```console
+    node report.js
+    ```
 
 This will generate data and Markdown in `/output/`.
 
@@ -24,7 +39,6 @@ This will generate data and Markdown in `/output/`.
 ecnites is designed to be run on a cron, so you consistently get data and can backfill any new GitHub events that encites adds in future versions from raw data that it outputs.
 
 There's an exmaple GitHub action in this repository. You'll likely be able to copy/paste most of it, and modify it as necessary to suit your needs. You will be able to see example runs in the Actions tab of this repository.
-
 
 ## More Information
 

--- a/README.md
+++ b/README.md
@@ -13,23 +13,16 @@ This is a basic report that you can run, showing off the most complicated potent
 To generate a report:
 
 1. Clone the repo
-
-2. Remove the `output/` directory
-
-3. Update the `people` array in [util/people.js](util/people.js)
-
-4. [Configure GitHub authentication](https://github.com/cutenode/encites#environment-variables)
-
-5. Install the example report tool
-
+1. Remove the `output/` directory (`rm -rf ./output`)
+1. Update the `people` array in [util/people.js](util/people.js) with your GitHub username
+1. Configure [GitHub authentication](https://github.com/cutenode/encites#environment-variables)
+1. Install the project's dependencies
     ```console
     npm install
     ```
-
-6. Run the example report generator
-
+1. Run the example report generator
     ```console
-    node report.js
+    node report.js # or `npm run report`
     ```
 
 This will generate data and Markdown in `/output/`.

--- a/util/dates.js
+++ b/util/dates.js
@@ -1,14 +1,16 @@
 const { DateTime } = require('luxon')
 
 const now = DateTime.now()
+const currentYear = now.year
 const lastMonth = now.minus({ months: 1 })
 const lastDayOfPreviousMonth = lastMonth.set({ day: lastMonth.daysInMonth })
 
 const dates = {
   now: now.toISODate(), // make `now` usable with ISO date format
   lastDayOfPreviousMonth: lastDayOfPreviousMonth.toISODate(), // gets the last day of the previous month
-  checkFrom: `2021-${lastDayOfPreviousMonth.month.toString().padStart(2, 0)}-01`, // yyyy-mm-dd
-  checkUntil: `2021-${lastDayOfPreviousMonth.month.toString().padStart(2, 0)}-${lastDayOfPreviousMonth.daysInMonth.toString().padStart(2, 0)}` // yyyy-mm-dd-yyyy-mm-dd
+  checkFrom: `${currentYear}-${lastDayOfPreviousMonth.month.toString().padStart(2, 0)}-01`, // yyyy-mm-dd
+  checkUntil: `${currentYear}-${lastDayOfPreviousMonth.month.toString().padStart(2, 0)}-${lastDayOfPreviousMonth.daysInMonth.toString().padStart(2, 0)}` // yyyy-mm-dd-yyyy-mm-dd
 }
 
+console.log(currentYear)
 module.exports = dates


### PR DESCRIPTION
@bnb -- Such a cool tool! I was able to generate my first report after poking at it a little: https://gist.github.com/justaugustus/31189f4d4c69161379430b8eeca67fff

PR-ing some minor updates to the instructions and dates :)

- util/dates.js: Allow current year to be dynamically generated
  JSON data will be generated, but the markdown report will not be
  populated without this.

- README.md: Add a few more notes about report generation

Signed-off-by: Stephen Augustus <foo@auggie.dev>